### PR TITLE
fix(stata): rename and update Stata pkg and toc files

### DIFF
--- a/stata.toc
+++ b/stata.toc
@@ -1,3 +1,3 @@
 v 1.0
 d Jeffrey D. Michler, jdmichler@arizona.edu
-p 'Stata': some code snippets that I don't want to keep writing
+p wxsum Stata Weather Command

--- a/wxsum.pkg
+++ b/wxsum.pkg
@@ -1,10 +1,11 @@
 v 0.1
 d
-d 'StataConfig': some basic ado files
+d 'wxsum': Stata Weather Command
 d
-d Distribution-Date: 20200523
+d Distribution-Date: 20240411
 d
 d Author: Jeffrey D. Michler
 d Support: jdmichler@arizona.edu
 d
 f wxsum.ado
+f wxsum.sthlp


### PR DESCRIPTION
Resolves a "file not found" error when attempting to install the wxsum Stata package from the repository by renaming `StataConfig.pkg` to `wxsum.pkg`. Both `wxsum.pkg` and `stata.toc` have also been updated to reflect the new package metadata and include `wxsum.sthlp` for installation.

---
*PR created automatically by Jules for task [7919459728074395016](https://jules.google.com/task/7919459728074395016) started by @jdavidm*