### PR TITLE
Fix syntax error caused by extra closing brace in wxsum.ado

### DIFF
--- a/wxsum.ado
+++ b/wxsum.ado
@@ -412,7 +412,6 @@ forvalues j = 1979(1)2040 {
 			label var sd_`k' "Std dev of percentage of days in the `k'th percentile across all seasons"
 		}
 	}
-}
 
 
 ***********


### PR DESCRIPTION
This pull request fixes a syntax error (`} is not a valid command name` with `r(199)`) in `wxsum.ado`. The error was caused by an extraneous closing brace `}` at the end of the script, likely resulting from nested loop changes. This removes the unmatched brace, restoring execution flow.

---
*PR created automatically by Jules for task [11943758893385733576](https://jules.google.com/task/11943758893385733576) started by @jdavidm*