### PR TITLE
Fix wxsum syntax issues

### DIFF
--- a/wxsum.ado
+++ b/wxsum.ado
@@ -42,10 +42,10 @@ version 15.1
 
 *0.0) If day is missing, it is assumed to be 01
 
-if "'`ini_day'" == "" {
+if "`ini_day'" == "" {
 	loc ini_day = "01"
 }
-if "'`fin_day'" == "" {
+if "`fin_day'" == "" {
 	loc fin_day = "01"
 }
 
@@ -104,7 +104,9 @@ forvalues j = 1979(1)2040 {
 	*tempname mat_`j'
 	
 	qui: cap unab check_vars : `anything'`j'*
-	if _rc != 0 continue
+	if _rc != 0 {
+		continue
+	}
 
 	foreach month of loc months  {
 		foreach day of loc days  {


### PR DESCRIPTION
This fixes two issues:
1. `ini_day` and `fin_day` checks had single-quotes preventing them from matching empty strings properly.
2. The `continue` instruction on a single-line `if` was causing Stata to lose tracking of `{` curly blocks. This is a known issue with Stata. Fixing it to be a block `if` resolves the issue.

---
*PR created automatically by Jules for task [9774061317199893578](https://jules.google.com/task/9774061317199893578) started by @jdavidm*