### PR TITLE
Fix Stata parser error by wrapping continue in block if

### DIFF
--- a/wxsum.ado
+++ b/wxsum.ado
@@ -104,7 +104,9 @@ forvalues j = 1979(1)2040 {
 	*tempname mat_`j'
 	
 	qui: cap unab check_vars : `anything'`j'*
-	if _rc != 0 continue
+	if _rc != 0 {
+		continue
+	}
 
 	foreach month of loc months  {
 		foreach day of loc days  {


### PR DESCRIPTION
This pull request fixes a Stata runtime parsing error (`} is not a valid command name`, `r(199)`) that happens because Stata's loop depth tracking breaks when `continue` or `break` is used in a single-line `if` statement. Wrapping the `continue` in a standard block `if` loop ensures proper iteration and execution.

---
*PR created automatically by Jules for task [17606232587211891616](https://jules.google.com/task/17606232587211891616) started by @jdavidm*